### PR TITLE
Add quickstart bash script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ langchain-local-template/
 - VS Code (recommended for development)
 
 ## Setup
+ 
+### Quickstart
+Run the provided script to set up a virtual environment, install dependencies and start a demo chat:
+```bash
+chmod +x quickstart.sh
+./quickstart.sh
+```
+
 
 ### Make a copy of this repo
    ```bash

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Quickstart script to set up the environment and run the demo
+set -e
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "$PROJECT_ROOT/venv" ]; then
+    python3 -m venv "$PROJECT_ROOT/venv"
+fi
+
+# Activate the environment
+source "$PROJECT_ROOT/venv/bin/activate"
+
+# Upgrade pip to avoid using an outdated version
+pip install --upgrade pip >/dev/null
+
+# Install project dependencies
+pip install -e "$PROJECT_ROOT" -v
+pip install -e "$PROJECT_ROOT[dev]" -v
+
+# Sync available models with Ollama
+python "$PROJECT_ROOT/src/utils/sync_models.py"
+
+# Run the interactive chat script
+python "$PROJECT_ROOT/src/test_chat.py" "$@"


### PR DESCRIPTION
## Summary
- add `quickstart.sh` that sets up a virtual environment, installs deps and runs the sample chat
- document quick start usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846afa80e888327a5b36a7ce063c3d2