### PR TITLE
Add Windows setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,27 +39,34 @@ Or, on GitHub:
 * Name your new repository and set it to public or private as desired.
 
 ### Automated Setup
-First, make the setup scripts executable:
+#### macOS/Linux
+Make the setup scripts executable and run them:
 ```bash
 chmod +x env-setup/*.sh
-```
-Run both scripts to set up Python, Pipenv, and project dependencies:
-```bash
-./env-setup/setup-mac-python.sh
+./env-setup/setup-mac-python-env.sh
 ./env-setup/setup-langchain-project.sh
+```
+
+#### Windows
+From a PowerShell prompt run:
+```powershell
+./env-setup/setup-windows-python-env.ps1
+./env-setup/setup-windows-langchain-project.ps1
 ```
 
 #### Individual Setup
-You can also run the scripts individually:
+You can also run the scripts separately.
 
-1. Set up Python and Pipenv:
+**macOS/Linux**
 ```bash
-./env-setup/setup-mac-python.sh
+./env-setup/setup-mac-python-env.sh
+./env-setup/setup-langchain-project.sh
 ```
 
-2. Set up project dependencies with Pipenv:
-```bash
-./env-setup/setup-langchain-project.sh
+**Windows**
+```powershell
+./env-setup/setup-windows-python-env.ps1
+./env-setup/setup-windows-langchain-project.ps1
 ```
 
 

--- a/env-setup/setup-windows-langchain-project.ps1
+++ b/env-setup/setup-windows-langchain-project.ps1
@@ -1,0 +1,31 @@
+# PowerShell script to set up LangChain project dependencies using Pipenv
+Write-Host "Setting up LangChain project dependencies..." -ForegroundColor Green
+
+if (-not (Test-Path "pyproject.toml")) {
+    Write-Error "pyproject.toml not found. Are you in the project root directory?"
+    exit 1
+}
+
+if (-not (Get-Command pipenv -ErrorAction SilentlyContinue)) {
+    Write-Error "Pipenv not found. Please install it first (see setup-windows-python-env.ps1)."
+    exit 1
+}
+
+$pythonVersion = (python --version).Split()[1]
+$pyMajorMinor = ($pythonVersion -split '\.')[0..1] -join '.'
+
+Write-Host "Initializing Pipenv environment..." -ForegroundColor Green
+pipenv --python $pyMajorMinor
+
+Write-Host "Installing project dependencies..." -ForegroundColor Green
+pipenv install -e .
+
+Write-Host "Installing development dependencies..." -ForegroundColor Green
+pipenv install -e .[dev]
+
+Write-Host "Verifying LangChain installation..." -ForegroundColor Green
+pipenv run python -c "import langchain; print(f'LangChain version: {langchain.__version__}')"
+
+Write-Host "\nLangChain project setup complete!" -ForegroundColor Green
+Write-Host "To activate the environment, run: pipenv shell" -ForegroundColor Yellow
+Write-Host "To run a script without activating: pipenv run python src\\your_script.py" -ForegroundColor Yellow

--- a/env-setup/setup-windows-python-env.ps1
+++ b/env-setup/setup-windows-python-env.ps1
@@ -1,0 +1,29 @@
+# PowerShell script to install Python and Pipenv on Windows
+# Run this script with Administrator privileges if possible
+
+Write-Host "Setting up Python development environment on Windows..." -ForegroundColor Green
+
+# Check for winget
+$winget = Get-Command winget -ErrorAction SilentlyContinue
+
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    if ($winget) {
+        Write-Host "Python not found. Installing via winget..." -ForegroundColor Yellow
+        winget install --exact --id Python.Python.3.11 -h
+    } else {
+        Write-Warning "Python not found and winget is unavailable. Please install Python manually."
+    }
+} else {
+    $ver = (python --version).Trim()
+    Write-Host "Python already installed: $ver" -ForegroundColor Green
+}
+
+if (-not (Get-Command pipenv -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing Pipenv..." -ForegroundColor Green
+    python -m pip install --user pipenv
+} else {
+    Write-Host "Pipenv already installed: $(pipenv --version)" -ForegroundColor Green
+}
+
+Write-Host "\nAdd the Python Scripts directory to your PATH if it isn't already." -ForegroundColor Yellow
+Write-Host "Windows Python environment setup complete!" -ForegroundColor Green

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -1,32 +1,36 @@
-# tests/test_model_loading.py
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
 import pytest
-from src.models.factory import get_model
+from models.factory import get_model
+from models.configs import get_model_config
+
 
 def test_model_loading():
-    """Test that we can load a model from config"""
+    """Models can be loaded from config"""
     model = get_model("llama2")
     assert model is not None
     assert model.provider == "ollama"
 
-# tests/test_chat_responses.py
+
 def test_basic_response():
-    """Test that model gives reasonable responses"""
+    """Model gives a simple answer"""
     model = get_model("llama2")
     response = model.model("What is 2+2?")
     assert "4" in response.lower()
 
-# tests/test_config_loading.py
-from src.models.configs import get_model_config
 
 def test_config_loading():
-    """Test that we can load configurations"""
+    """Configurations load correctly"""
     config = get_model_config("llama2")
     assert config.model_name == "llama2"
     assert config.provider == "ollama"
     assert "temperature" in config.params
 
-# tests/test_error_handling.py
+
 def test_invalid_model():
-    """Test error handling for invalid model names"""
+    """Invalid model names raise errors"""
     with pytest.raises(ValueError):
         get_model("nonexistent_model")


### PR DESCRIPTION
## Summary
- add PowerShell scripts to install Python/Pipenv and project deps on Windows
- document Windows setup in README
- replace old combined tests with `tests/test_langchain.py`

## Testing
- `ruff check src tests env-setup`
- `pytest -q` *(fails: ValueError: Unknown model: llama2)*

------
https://chatgpt.com/codex/tasks/task_e_6846cd3bfd4c8327a32b2f6970557a61